### PR TITLE
SuperBLT Update - In game update

### DIFF
--- a/.github/workflows/realease.yml
+++ b/.github/workflows/realease.yml
@@ -1,0 +1,61 @@
+name: Create Realease
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push any tag
+  push:
+    tags:
+    - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Update version on mod.txt and meta.json
+      uses: satackey/action-js-inline@v0.0.2
+      with:
+        script: |
+          const fs = require('fs')
+          const ref = process.env.GITHUB_REF
+          const tag = ref.split('/')[2]
+          let dataMod = fs.readFileSync('mod.txt', 'utf8');
+          dataMod = dataMod.replace(/("version": "(.)*",)/gm, `"version": "${tag}",`)
+          fs.writeFileSync('mod.txt', dataMod)
+          fs.writeFileSync('meta.json', JSON.stringify([
+            {
+              "ident": "ultimate-trainer-update",
+              "version": tag,
+              "patchnotes_url": "https://github.com/pierre-josselin/payday-2-ultimate-trainer-5/blob/main/CHANGELOG.md",
+              "download_url": `https://github.com/pierre-josselin/payday-2-ultimate-trainer-5/releases/download/${tag}/release.zip`
+            }
+          ], null, 2))
+
+    - name: Commit changes
+      uses: devops-infra/action-commit-push@master
+      with:
+        github_token: "${{ secrets.GITHUB_TOKEN }}"
+        commit_prefix: "[AUTO]"
+        commit_message: " Update version on mod.txt and meta.json"
+        force: false
+        target_branch: main
+
+    - name: Move files
+      run: |
+        mkdir payday-2-ultimate-trainer-5
+        mv $(echo * | sed s:payday-2-ultimate-trainer-5::g) ./payday-2-ultimate-trainer-5
+
+    - name: Archive Release
+      uses: thedoctor0/zip-release@main
+      with:
+        type: 'zip'
+        filename: 'release.zip'
+        exclusions: '*.git* *.github*'
+
+    - name: Upload Release
+      uses: ncipollo/release-action@v1
+      with:
+        artifacts: "release.zip"
+        omitName: true
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## 5.3.0
+### New features
+
+- SuperBLT Update
+
+## 5.2.2 (2022-05-27)
 
 ### New features
 
@@ -41,4 +46,4 @@
 
 ## 5.0.0-alpha (2022-03-02)
 
-Initial release
+- Initial release

--- a/README-UC.txt
+++ b/README-UC.txt
@@ -1,7 +1,7 @@
 [SIZE="2"]
 [SIZE="6"][COLOR="Red"]Ultimate Trainer 5[/COLOR][/SIZE]
 
-[SIZE="4"]5.3.0[/SIZE]
+[SIZE="4"]Version 5.3.0[/SIZE]
 
 [YOUTUBE_ID]zLbhBmSaKZ8[/YOUTUBE_ID]
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,25 @@ DLC and skin unlockers.
 
 If you want to contribute to the project by adding a language, make a copy of the [english locale](https://github.com/pierre-josselin/payday-2-ultimate-trainer-5/blob/main/locales/en.json).
 
+## How to publish a new version
+The release creation flow is automated using github actions.
+
+- The version of `meta.json` and `mod.txt` are generated automatically according to the given tag.
+
+1. Make your adjustments and push to the `main` branch.
+2. Create a tag with the new version and push
+    ```
+    git tag -a <version> -m <realease_message>
+    git push origin <version>
+    ```
+    Example:
+    ```
+    git tag -a 5.3.0 -m '5.3.0'
+    git push origin 5.3.0
+    ```
+
+- You can edit/delete the release after creation
+
 ## Credits
 
 Most of the features of Ultimate Trainer are developed by me (Pierre Josselin).  
@@ -170,6 +189,7 @@ But sometimes I use code created by other developers or other developers contrib
 
 Vinícius Francisco Xavier
 
+- SuperBLT Update
 - Invisible Player
 - Noclip
 - Shoot through walls

--- a/meta.json
+++ b/meta.json
@@ -1,0 +1,8 @@
+[
+  {
+    "ident": "ultimate-trainer-update",
+    "version": "5.3.0",
+    "patchnotes_url": "https://github.com/pierre-josselin/payday-2-ultimate-trainer-5/blob/main/CHANGELOG.md",
+    "download_url": "https://github.com/pierre-josselin/payday-2-ultimate-trainer-5/releases/latest/download/release.zip"
+  }
+]

--- a/mod.txt
+++ b/mod.txt
@@ -3,6 +3,15 @@
     "description": "Ultimate Trainer",
     "author": "Pierre Josselin",
     "version": "5.3.0",
+    "updates": [
+        {
+            "identifier": "ultimate-trainer-update",
+            "host": {
+                "meta": "https://raw.githubusercontent.com/pierre-josselin/payday-2-ultimate-trainer-5/main/meta.json",
+                "patchnotes": "https://github.com/pierre-josselin/payday-2-ultimate-trainer-5/blob/main/CHANGELOG.md"
+            }
+        }
+    ],
     "hooks": [
         {
             "hook_id": "core/lib/setups/coresetup",


### PR DESCRIPTION
- Auto generate realese
- Auto set version files

---

### Attention: The mod folder cannot be versioned for the update to work

If your mod folder contains the `.git` folder (it is a hidden folder) SuperBLT will stop the automatic update.
Here's evidence: https://gitlab.com/znixian/payday2-superblt-lua/-/blob/master/req/BLTDownloadManager.lua#L97-108

---

@pierre-josselin I already rebase this branch with your `5.3.0` branch

@pierre-josselin Need to see if github actions is active for the repository, most likely it is.

@pierre-josselin need to create a tag to work I described it better in README.md

- The version of `meta.json` and `mod.txt` are generated automatically according to the given tag.
- Create a tag with the new version and push
    ```
    git tag -a <version> -m <realease_message>
    git push origin <version>
    ```
    Example:
    ```
    git tag -a 5.3.0 -m '5.3.0'
    git push origin 5.3.0
    ```

---

Old but valid documentation -> https://superblt.znix.xyz/doc/updates/